### PR TITLE
Simplify and optimize visualize

### DIFF
--- a/include/Sample.h
+++ b/include/Sample.h
@@ -52,6 +52,7 @@ public:
 	// if there appears problems with playback on some interpolation mode, then the value for that mode
 	// may need to be higher - conversely, to optimize, some may work with lower values
 	static constexpr auto s_interpolationMargins = std::array<int, 5>{64, 64, 64, 4, 4};
+	static constexpr int s_min_resolution = 512;
 
 	enum class Loop
 	{


### PR DESCRIPTION
This PR simplifies and optimizes `Sample::visualize()`. The main optimizations is not taking every frame into account, but instead skipping a few.

Previously, visualizing a 5 minute long sample took 110ms, with this PR it takes 1ms. 

The only drawback is that now the algorithm isn't totally deterministic, if you change the starting frame by 1 the result might be slightly different. This is not really noticeable in normal use however. You can increase the resolution by setting `s_min_resolution` higher. And even if you remove this optimization, the code is still around 10% faster due to less operations in the main `for` loop.

Here is an example, as you can see it is pretty much identical:

Old
![image](https://github.com/sakertooth/lmms/assets/47889291/7f5d8aad-0452-47f5-ab88-b8dc53e23772)

New
![image](https://github.com/sakertooth/lmms/assets/47889291/910569e8-e873-42af-8967-695fff6176fa)


Feel free to completely disregard this, I was working on something totally separate and needed a fast visualization function, so I thought it might fit into this PR.